### PR TITLE
Fix for #1377

### DIFF
--- a/drake/systems/plants/solveLCPmex.cpp
+++ b/drake/systems/plants/solveLCPmex.cpp
@@ -316,17 +316,17 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] ) {
           -BIG * VectorXd::Ones(nP),
           VectorXd::Zero(nC + mC * nC + nC);
     ub = BIG * VectorXd::Ones(lcp_size);
-    
+
     MatrixXd M(lcp_size, lcp_size);
     Map<VectorXd> w(mxGetPrSafe(mxw), lcp_size);
 
     //build LCP matrix
     M << h * JL_possible * Mvn,
-         h * JP * Mvn,
+         h * JP_velocity * Mvn,
          h * n_possible * Mvn,
          D_possible * Mvn,
          MatrixXd::Zero(nC, lcp_size);
-    
+
 
     if (nC > 0) {
       for (size_t i = 0; i < mC ; i++) {
@@ -339,7 +339,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] ) {
 
     //build LCP vector
     w << phiL_possible + h *  JL_possible * wvn,
-         phiP + h *  JP * wvn,
+         phiP + h *  JP_velocity * wvn,
          phiC_possible + h * n_possible * wvn,
          D_possible * wvn,
          VectorXd::Zero(nC);

--- a/drake/systems/plants/test/momentumTest.m
+++ b/drake/systems/plants/test/momentumTest.m
@@ -62,16 +62,7 @@ for t=0:0.05:T
   valuecheck(Adot_times_v, Adot_times_v_mat);
   
   % test physics
-  h = A*v;
-  omega = v(1:3);
-  x = forwardKin(r, kinsol, 2, zeros(3, 1), struct('rotation_type', 2));
-  quat = x(4 : 7);
-  R_body_to_world = quat2rotmat(quat);
-  angular_momentum = R_body_to_world * body.inertia * omega; % in world frame
-  linear_momentum = R_body_to_world * body.mass * v(4:6);
-
-  valuecheck(h(1:3),angular_momentum); 
-  valuecheck(h(4:6),linear_momentum);
+  checkSingleQuatBodyMomentum(r, kinsol, A, v);
   
   if display
     xyzrpy = forwardKin(r,kinsol,2,[0;0;0],1);
@@ -150,16 +141,7 @@ for t=0:0.05:T
   
   A = centroidalMomentumMatrix(r, kinsol);
 
-  h = A*v;
-  omega = v(1:3);
-  x = forwardKin(r, kinsol, 2, zeros(3, 1), struct('rotation_type', 2));
-  quat = x(4 : 7);
-  R_body_to_world = quat2rotmat(quat);
-  angular_momentum = R_body_to_world * body.inertia * omega; % in world frame
-  linear_momentum = R_body_to_world * body.mass * v(4:6);
-
-  valuecheck(h(1:3),angular_momentum); 
-  valuecheck(h(4:6),linear_momentum);
+  checkSingleQuatBodyMomentum(r, kinsol, A, v);
   
   if display
     xyzrpy = forwardKin(r,kinsol,2,[0;0;0],1);
@@ -211,4 +193,18 @@ for t=0:0.05:T
   end
 end
 
+end
+
+function checkSingleQuatBodyMomentum(r, kinsol, A, v)
+h = A*v;
+body_id = 2;
+body = r.getBody(body_id);
+x = forwardKin(r, kinsol, body_id, zeros(3, 1), struct('rotation_type', 2));
+quat = x(4 : 7);
+R_body_to_world = quat2rotmat(quat);
+angular_momentum = R_body_to_world * body.inertia * v(1:3); % in world frame
+linear_momentum = R_body_to_world * body.mass * v(4:6);
+
+valuecheck(h(1:3),angular_momentum);
+valuecheck(h(4:6),linear_momentum);
 end

--- a/drake/systems/plants/test/momentumTest.m
+++ b/drake/systems/plants/test/momentumTest.m
@@ -16,14 +16,9 @@ if display
   lcmgl = drake.util.BotLCMGLClient(lcm.lcm.LCM.getSingleton(),'qp-control-block-debug');
 end
 
-x0 = zeros(13,1);
+manipulator = r.getManipulator();
+x0 = [getRandomConfiguration(manipulator); randn(manipulator.getNumVelocities(), 1)];
 x0(3) = 15;
-x0(6+1) = rand()-.5;
-x0(6+2) = rand()-.5;
-x0(6+3) = 10*rand();
-x0(6+4) = 0.5*(rand()-.5);
-x0(6+5) = 0.5*(rand()-.5);
-x0(6+6) = 0.5*(rand()-.5);
 
   function A = myfun(q)
     % for derivative check
@@ -45,7 +40,7 @@ for t=0:0.05:T
   end
   q = x(1:nq);
   v = x(nq+(1:nv));
-  qd = r.getManipulator().vToqdot(q)*v;
+  qd = manipulator.vToqdot(q)*v;
   
   % test derivative
   [A,dAdq] = geval(@myfun,q);
@@ -54,25 +49,29 @@ for t=0:0.05:T
     Adot_tv = Adot_tv + reshape(dAdq(:,jj),size(A)) * qd(jj);
   end
   
-  kinsol = doKinematics(r, q, false, true, qd);
+  kinsol = doKinematics(r, q, v);
   A = centroidalMomentumMatrix(r, kinsol);
   Adot_times_v = centroidalMomentumMatrixDotTimesV(r, kinsol);
   valuecheck(Adot_times_v,Adot_tv * v);
 
   % test mex
-  kinsol_matlab = doKinematics(r, q, false, false, qd);
+  kinsol_matlab = doKinematics(r, q, v, struct('use_mex', false));
   A_mat = centroidalMomentumMatrix(r, kinsol_matlab);
   Adot_times_v_mat = centroidalMomentumMatrixDotTimesV(r, kinsol_matlab);
   valuecheck(A, A_mat);
   valuecheck(Adot_times_v, Adot_times_v_mat);
   
   % test physics
-  h = A*qd;
-  omega = v(4:6);
-  am = body.inertia * omega;
+  h = A*v;
+  omega = v(1:3);
+  x = forwardKin(r, kinsol, 2, zeros(3, 1), struct('rotation_type', 2));
+  quat = x(4 : 7);
+  R_body_to_world = quat2rotmat(quat);
+  angular_momentum = R_body_to_world * body.inertia * omega; % in world frame
+  linear_momentum = R_body_to_world * body.mass * v(4:6);
 
-  valuecheck(h(1:3),am); 
-  valuecheck(h(4:6),body.mass*qd(1:3));
+  valuecheck(h(1:3),angular_momentum); 
+  valuecheck(h(4:6),linear_momentum);
   
   if display
     xyzrpy = forwardKin(r,kinsol,2,[0;0;0],1);
@@ -107,7 +106,7 @@ for t=0:0.05:T
     lcmgl.glEnd();
 
     % draw angular momentum vector
-    aa_m = rpy2axis(am(1:3));
+    aa_m = rpy2axis(angular_momentum(1:3));
     lcmgl.glLineWidth(3);
     lcmgl.glBegin(lcmgl.LCMGL_LINES);
     lcmgl.glColor3f(1, 0, 0);
@@ -126,19 +125,13 @@ end
 
 clear r;
 r = TimeSteppingRigidBodyManipulator('brick1.urdf',0.005,options);
+manipulator = r.getManipulator();
 if display
   v = r.constructVisualizer();
 end
 
-x0 = zeros(13,1);
+x0 = [getRandomConfiguration(manipulator); randn(manipulator.getNumVelocities(), 1)];
 x0(3) = 15;
-x0(6+1) = randn();
-x0(6+2) = randn();
-x0(6+3) = 10*rand();
-x0(6+4) = 0.5*randn();
-x0(6+5) = 0.5*randn();
-x0(6+6) = 0.5*randn();
-
 
 T = 3.0;
 xtraj = r.simulate([0 T],x0);
@@ -153,18 +146,21 @@ for t=0:0.05:T
   end
   q = x(1:nq);
   v = x(nq+(1:nv));
-  qd = r.getManipulator().vToqdot(q)*v;
-  kinsol = doKinematics(r,q,false,true);
+  kinsol = doKinematics(r,q);
   
   A = centroidalMomentumMatrix(r, kinsol);
-  h = A*qd;
+
+  h = A*v;
+  omega = v(1:3);
+  x = forwardKin(r, kinsol, 2, zeros(3, 1), struct('rotation_type', 2));
+  quat = x(4 : 7);
+  R_body_to_world = quat2rotmat(quat);
+  angular_momentum = R_body_to_world * body.inertia * omega; % in world frame
+  linear_momentum = R_body_to_world * body.mass * v(4:6);
+
+  valuecheck(h(1:3),angular_momentum); 
+  valuecheck(h(4:6),linear_momentum);
   
-  omega = v(4:6);
-  am = body.inertia * omega;
-
-  valuecheck(h(1:3),am); 
-  valuecheck(h(4:6),body.mass*qd(1:3));
-
   if display
     xyzrpy = forwardKin(r,kinsol,2,[0;0;0],1);
     xcom = getCOM(r,kinsol);
@@ -198,7 +194,7 @@ for t=0:0.05:T
     lcmgl.glEnd();
 
     % draw angular momentum vector
-    aa_m = rpy2axis(am(1:3));
+    aa_m = rpy2axis(angular_momentum(1:3));
     lcmgl.glLineWidth(3);
     lcmgl.glBegin(lcmgl.LCMGL_LINES);
     lcmgl.glColor3f(1, 0, 0);


### PR DESCRIPTION
Fixes https://github.com/RobotLocomotion/drake/issues/1377.

There were bugs in momentumTest itself, but also in solveLCPmex (@mposa, could you check?).

I'm not happy with the fact that momentumTest caught a bug in solveLCPmex; makes me wonder why more dedicated tests are not hitting this part of the code. Especially since I was about to propose removing momentumTest, as testCentroidalMomentumMatrix and testCentroidalMomentumMatrixDotTimesV do a better job of actually testing momentum related methods.