### PR TITLE
Changes to get things to compile on g++

### DIFF
--- a/drake/examples/Pendulum/runDynamics.cpp
+++ b/drake/examples/Pendulum/runDynamics.cpp
@@ -9,7 +9,7 @@ int main(int argc, char* argv[]) {
   if(!lcm->good())
    return 1;
 
-  DrakeSystemPtr p = allocate_shared<PendulumWithBotVis>(Eigen::aligned_allocator<PendulumWithBotVis>(),lcm);
+  DrakeSystemPtr p(new PendulumWithBotVis(lcm));
   runLCM(p,*lcm,0,50,p->getRandomState());
 
   cout << "output frame: " << p->getOutputFrame() << endl;

--- a/drake/examples/Pendulum/runLQR.cpp
+++ b/drake/examples/Pendulum/runLQR.cpp
@@ -9,7 +9,7 @@ int main(int argc, char* argv[]) {
   if(!lcm->good())
     return 1;
 
-  std::shared_ptr<PendulumWithBotVis> pendulum = allocate_shared<PendulumWithBotVis>(Eigen::aligned_allocator<PendulumWithBotVis>(),lcm);
+  std::shared_ptr<PendulumWithBotVis> pendulum(new PendulumWithBotVis(lcm));
   DrakeSystemPtr controller = pendulum->balanceLQR();
 
   DrakeSystemPtr sys = feedback(pendulum,controller);

--- a/drake/systems/plants/RigidBodyManipulator.cpp
+++ b/drake/systems/plants/RigidBodyManipulator.cpp
@@ -42,7 +42,8 @@ RigidBodyManipulator::RigidBodyManipulator(const std::string &urdf_filename, con
 {
   a_grav << 0, 0, 0, 0, 0, -9.81;
 
-  shared_ptr<RigidBody> b = allocate_shared<RigidBody>(Eigen::aligned_allocator<RigidBody>());
+  shared_ptr<RigidBody> b(new RigidBody());
+  make_shared<RigidBody>();
   b->linkname = "world";
   b->robotnum = 0;
   b->body_index = 0;
@@ -58,7 +59,7 @@ RigidBodyManipulator::RigidBodyManipulator(void) :
 {
   a_grav << 0, 0, 0, 0, 0, -9.81;
 
-  shared_ptr<RigidBody> b = allocate_shared<RigidBody>(Eigen::aligned_allocator<RigidBody>());
+  shared_ptr<RigidBody> b(new RigidBody());
   b->linkname = "world";
   b->robotnum = 0;
   b->body_index = 0;

--- a/drake/systems/plants/constructModelmex.cpp
+++ b/drake/systems/plants/constructModelmex.cpp
@@ -70,7 +70,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
     //DEBUG
     //mexPrintf("constructModelmex: body %d\n",i);
     //END_DEBUG
-    shared_ptr<RigidBody> b = allocate_shared<RigidBody>(Eigen::aligned_allocator<RigidBody>());
+    shared_ptr<RigidBody> b(new RigidBody());
     b->body_index = i;
 
     b->linkname = mxGetStdString(mxGetPropertySafe(pBodies, i, "linkname"));
@@ -352,7 +352,7 @@ void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
   //mexPrintf("constructModelmex: Parsing frames\n");
   //END_DEBUG
   for (int i = 0; i < num_frames; i++) {
-    shared_ptr<RigidBodyFrame> fr = allocate_shared<RigidBodyFrame>(Eigen::aligned_allocator<RigidBodyFrame>());
+    shared_ptr<RigidBodyFrame> fr(new RigidBodyFrame());
 
 	fr->name = mxGetStdString(mxGetPropertySafe(pFrames, i, "name"));
 


### PR DESCRIPTION
Instead of using allocate_shared or make_shared, just use shared_ptr constructor with new.

I think this should work on Windows as well. Although make_shared is usually preferred over just using new to create a sharejd_ptr, I read that make_shared doesn't actually use new to allocate (instead it uses placement new), so it doesn't use the operator new generated by the EIGEN_MAKE_ALIGNED_OPERATOR_NEW macro. That's probably why you switched to using allocate_shared. But for some reason g++ doesn't like that.