### PR TITLE
Aligned unordered_map fix.

### DIFF
--- a/drake/systems/controllers/QPCommon.cpp
+++ b/drake/systems/controllers/QPCommon.cpp
@@ -480,7 +480,7 @@ int setupAndSolveQP(
 
   // handle external wrenches to compensate for
   typedef GradientVar<double, TWIST_SIZE, 1> WrenchGradientVarType;
-  std::unordered_map<RigidBody const *, GradientVar<double, TWIST_SIZE, 1> > f_ext;
+  eigen_aligned_unordered_map<RigidBody const *, GradientVar<double, TWIST_SIZE, 1> > f_ext;
   for (auto it = qp_input->body_wrench_data.begin(); it != qp_input->body_wrench_data.end(); ++it) {
     const drake::lcmt_body_wrench_data& body_wrench_data = *it;
     int body_id = body_wrench_data.body_id - 1;

--- a/drake/systems/controllers/QPControllermex.cpp
+++ b/drake/systems/controllers/QPControllermex.cpp
@@ -275,7 +275,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     }
   }
 
-  std::unordered_map<RigidBody const *, GradientVar<double, TWIST_SIZE, 1> > f_ext;
+  eigen_aligned_unordered_map<RigidBody const *, GradientVar<double, TWIST_SIZE, 1> > f_ext;
   pdata->H = pdata->r->massMatrix(cache).value();
   pdata->C = pdata->r->dynamicsBiasTerm(cache, f_ext).value();
 

--- a/drake/systems/plants/RigidBodyManipulator.cpp
+++ b/drake/systems/plants/RigidBodyManipulator.cpp
@@ -1241,7 +1241,7 @@ GradientVar<Scalar, Eigen::Dynamic, Eigen::Dynamic> RigidBodyManipulator::massMa
  * Note that the wrenches in f_ext are expressed in body frame.
  */
 template <typename Scalar>
-GradientVar<Scalar, Eigen::Dynamic, 1> RigidBodyManipulator::dynamicsBiasTerm(KinematicsCache<Scalar>& cache, const std::unordered_map<RigidBody const *, GradientVar<Scalar, TWIST_SIZE, 1> >& f_ext, int gradient_order) const
+GradientVar<Scalar, Eigen::Dynamic, 1> RigidBodyManipulator::dynamicsBiasTerm(KinematicsCache<Scalar>& cache, const eigen_aligned_unordered_map<RigidBody const *, GradientVar<Scalar, TWIST_SIZE, 1> >& f_ext, int gradient_order) const
 {
   GradientVar<Scalar, Eigen::Dynamic, 1> vd(num_velocities, 1, num_positions + num_velocities, gradient_order);
   vd.value().setZero();
@@ -1256,7 +1256,7 @@ GradientVar<Scalar, Eigen::Dynamic, 1> RigidBodyManipulator::dynamicsBiasTerm(Ki
  */
 template <typename Scalar>
 GradientVar<Scalar, Eigen::Dynamic, 1> RigidBodyManipulator::inverseDynamics(KinematicsCache<Scalar>& cache,
-    const std::unordered_map<RigidBody const *, GradientVar<Scalar, TWIST_SIZE, 1> >& f_ext,
+    const eigen_aligned_unordered_map<RigidBody const *, GradientVar<Scalar, TWIST_SIZE, 1> >& f_ext,
     const GradientVar<Scalar, Eigen::Dynamic, 1>& vd, int gradient_order) const
 {
   if (gradient_order > 1)
@@ -1888,8 +1888,8 @@ template DLLEXPORT_RBM GradientVar<double, TWIST_SIZE, 1> RigidBodyManipulator::
 template DLLEXPORT_RBM GradientVar<double, 6, Dynamic> RigidBodyManipulator::worldMomentumMatrix<double>(KinematicsCache<double>&, int, const std::set<int>&, bool) const;
 template DLLEXPORT_RBM GradientVar<double, 6, 1> RigidBodyManipulator::transformSpatialAcceleration<double>(const KinematicsCache<double>&, GradientVar<double, 6, 1> const&, int, int, int, int) const;
 template DLLEXPORT_RBM GradientVar<double, 6, 1> RigidBodyManipulator::worldMomentumMatrixDotTimesV<double>(KinematicsCache<double>&, int, const std::set<int>&) const;
-template DLLEXPORT_RBM GradientVar<double, -1, 1> RigidBodyManipulator::inverseDynamics<double>(KinematicsCache<double>&, unordered_map<RigidBody const*, GradientVar<double, 6, 1> > const&, GradientVar<double, -1, 1, -1, 1> const&, int) const;
-template DLLEXPORT_RBM GradientVar<double, -1, 1> RigidBodyManipulator::dynamicsBiasTerm<double>(KinematicsCache<double>&, unordered_map<RigidBody const*, GradientVar<double, 6, 1> > const&, int) const;
+template DLLEXPORT_RBM GradientVar<double, -1, 1> RigidBodyManipulator::inverseDynamics<double>(KinematicsCache<double>&, eigen_aligned_unordered_map<RigidBody const*, GradientVar<double, 6, 1> > const&, GradientVar<double, -1, 1, -1, 1> const&, int) const;
+template DLLEXPORT_RBM GradientVar<double, -1, 1> RigidBodyManipulator::dynamicsBiasTerm<double>(KinematicsCache<double>&, eigen_aligned_unordered_map<RigidBody const*, GradientVar<double, 6, 1> > const&, int) const;
 
 template DLLEXPORT_RBM GradientVar<double, Eigen::Dynamic, 1> RigidBodyManipulator::positionConstraints(const KinematicsCache<double>&, int) const;
 

--- a/drake/systems/plants/RigidBodyManipulator.h
+++ b/drake/systems/plants/RigidBodyManipulator.h
@@ -12,6 +12,7 @@
 #include "KinematicPath.h"
 #include "ForceTorqueMeasurement.h"
 #include "GradientVar.h"
+#include "drakeUtil.h"
 #include <stdexcept>
 
 
@@ -358,10 +359,10 @@ public:
   GradientVar<Scalar, Eigen::Dynamic, Eigen::Dynamic> massMatrix(KinematicsCache<Scalar>& cache, int gradient_order = 0) const;
 
   template <typename Scalar>
-  GradientVar<Scalar, Eigen::Dynamic, 1> dynamicsBiasTerm(KinematicsCache<Scalar>& cache, const std::unordered_map<RigidBody const *, GradientVar<Scalar, TWIST_SIZE, 1> >& f_ext, int gradient_order = 0) const;
+  GradientVar<Scalar, Eigen::Dynamic, 1> dynamicsBiasTerm(KinematicsCache<Scalar>& cache, const eigen_aligned_unordered_map<RigidBody const *, GradientVar<Scalar, TWIST_SIZE, 1> >& f_ext, int gradient_order = 0) const;
 
   template <typename Scalar>
-  GradientVar<Scalar, Eigen::Dynamic, 1> inverseDynamics(KinematicsCache<Scalar>& cache, const std::unordered_map<RigidBody const *, GradientVar<Scalar, TWIST_SIZE, 1> >& f_ext, const GradientVar<Scalar, Eigen::Dynamic, 1>& vd, int gradient_order = 0) const;
+  GradientVar<Scalar, Eigen::Dynamic, 1> inverseDynamics(KinematicsCache<Scalar>& cache, const eigen_aligned_unordered_map<RigidBody const *, GradientVar<Scalar, TWIST_SIZE, 1> >& f_ext, const GradientVar<Scalar, Eigen::Dynamic, 1>& vd, int gradient_order = 0) const;
 
   template <typename DerivedV>
   GradientVar<typename DerivedV::Scalar, Eigen::Dynamic, 1> frictionTorques(Eigen::MatrixBase<DerivedV> const & v, int gradient_order = 0) const;

--- a/drake/systems/plants/constraint/RigidBodyConstraint.cpp
+++ b/drake/systems/plants/constraint/RigidBodyConstraint.cpp
@@ -2657,7 +2657,7 @@ void GravityCompensationTorqueConstraint::eval(const double* t, KinematicsCache<
 {
   VectorXd qd = VectorXd::Zero(robot->num_velocities);
   KinematicsCache<double> cache_zero_velocity = robot->doKinematics(cache.getQ(), qd, 1);
-  std::unordered_map<RigidBody const *, GradientVar<double, TWIST_SIZE, 1> > f_ext;
+  eigen_aligned_unordered_map<RigidBody const *, GradientVar<double, TWIST_SIZE, 1> > f_ext;
   auto G_gradientvar = robot->dynamicsBiasTerm(cache_zero_velocity, f_ext, 1);
 
   c.resize(num_constraint);

--- a/drake/systems/plants/rigidBodyManipulatorMexFunctions.cpp
+++ b/drake/systems/plants/rigidBodyManipulatorMexFunctions.cpp
@@ -205,7 +205,7 @@ void dynamicsBiasTermmex(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prh
 
   auto lambda = [](const RigidBodyManipulator &model, KinematicsCache<Scalar> &cache, const MatrixBase<DerivedF> &f_ext_value, const MatrixBase<DerivedDF> &f_ext_gradient, int gradient_order) {
 
-    unordered_map<const RigidBody *, GradientVar<Scalar, 6, 1> > f_ext;
+    eigen_aligned_unordered_map<const RigidBody *, GradientVar<Scalar, 6, 1> > f_ext;
 
     if (f_ext_value.size() > 0) {
       assert(f_ext_value.cols() == model.bodies.size());

--- a/drake/systems/plants/test/compareParsersmex.cpp
+++ b/drake/systems/plants/test/compareParsersmex.cpp
@@ -75,7 +75,7 @@ void mexFunction( int nlhs, mxArray *plhs[],int nrhs, const mxArray *prhs[] ) {
 		KinematicsCache<double> cpp_cache = cpp_model->doKinematics(cpp_q, cpp_v, 1);
 
 		{ // compare H, C, and B
-		  unordered_map<RigidBody const *, GradientVar<double, TWIST_SIZE, 1> > f_ext;
+			eigen_aligned_unordered_map<RigidBody const *, GradientVar<double, TWIST_SIZE, 1> > f_ext;
 
 		  auto matlab_H = matlab_model->massMatrix(matlab_cache);
 		  auto cpp_H = cpp_model->massMatrix(cpp_cache);

--- a/drake/systems/plants/test/debugManipulatorDynamics.cpp
+++ b/drake/systems/plants/test/debugManipulatorDynamics.cpp
@@ -26,7 +26,7 @@ int main()
   auto M = model.massMatrix<double>(cache, gradient_order);
   cout << M.value() << endl << endl;
 
-  unordered_map<RigidBody const *, GradientVar<double, TWIST_SIZE, 1> > f_ext;
+  eigen_aligned_unordered_map<RigidBody const *, GradientVar<double, TWIST_SIZE, 1> > f_ext;
   GradientVar<double, TWIST_SIZE, 1> f_ext_r_foot(TWIST_SIZE, 1, nq + nv, gradient_order);
   f_ext_r_foot.value().setRandom();
   f_ext_r_foot.gradient().value().setRandom();

--- a/drake/systems/plants/test/testKinematicsCacheChecks.cpp
+++ b/drake/systems/plants/test/testKinematicsCacheChecks.cpp
@@ -52,7 +52,7 @@ void performChecks(RigidBodyManipulator& model, KinematicsCache<double>& cache, 
   spatial_acceleration.value().setRandom();
   if (gradient_order > 0)
     spatial_acceleration.gradient().value().setRandom();
-  std::unordered_map<RigidBody const *, GradientVar<double, TWIST_SIZE, 1> > f_ext;
+  eigen_aligned_unordered_map<RigidBody const *, GradientVar<double, TWIST_SIZE, 1> > f_ext;
 
   if (gradient_order == 0) {
     checkForErrors(settings.expect_error_on_configuration_methods, model, &RigidBodyManipulator::centerOfMass<double>, cache, RigidBodyManipulator::default_robot_num_set);

--- a/drake/systems/plants/test/urdfManipulatorDynamicsTest.cpp
+++ b/drake/systems/plants/test/urdfManipulatorDynamicsTest.cpp
@@ -43,7 +43,7 @@ int main(int argc, char* argv[])
   auto H = model->massMatrix(cache);
   cout << H.value() << endl;
 
-  unordered_map<RigidBody const *, GradientVar<double, TWIST_SIZE, 1> > f_ext;
+  eigen_aligned_unordered_map<RigidBody const *, GradientVar<double, TWIST_SIZE, 1> > f_ext;
   auto C = model->dynamicsBiasTerm(cache, f_ext);
   cout << C.value() << endl;
 

--- a/drake/util/drakeUtil.h
+++ b/drake/util/drakeUtil.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <utility>
 #include <Eigen/Core>
+#include <unordered_map>
 
 #ifndef DRAKE_UTIL_H_
 #define DRAKE_UTIL_H_
@@ -23,6 +24,9 @@
 #else
     #define DLLEXPORT
 #endif
+
+template <typename Key, typename T>
+using eigen_aligned_unordered_map = std::unordered_map<Key, T, std::hash<Key>, std::equal_to<Key>, Eigen::aligned_allocator<std::pair<Key const, T > > >;
 
 template <typename Derived>
 inline void sizecheck(const Eigen::MatrixBase<Derived>& mat, size_t rows, size_t cols){


### PR DESCRIPTION
Add a convenient type alias for unordered_maps that use the Eigen::aligned_allocator, use to fix dynamicsBiasTerm and inverseDynamics.