### PR TITLE
fixup! Use a function pointer for cloning

### DIFF
--- a/geometry/optimization/convex_set.cc
+++ b/geometry/optimization/convex_set.cc
@@ -22,18 +22,26 @@ using solvers::VectorXDecisionVariable;
 using std::pair;
 using std::sqrt;
 
+ConvexSet::ConvexSet(
+    std::function<std::unique_ptr<ConvexSet>(const ConvexSet&)> cloner,
+    int ambient_dimension)
+    : cloner_(std::move(cloner)),
+      ambient_dimension_(ambient_dimension) {
+  DRAKE_DEMAND(ambient_dimension >= 0);
+}
+
 std::unique_ptr<ConvexSet> ConvexSet::Clone() const { return cloner_(*this); }
 
 HPolyhedron::HPolyhedron(const Eigen::Ref<const Eigen::MatrixXd>& A,
                          const Eigen::Ref<const Eigen::VectorXd>& b)
-    : ConvexSet(ConvexSetTag<HPolyhedron>(), A.cols()), A_{A}, b_{b} {
+    : ConvexSet(&ConvexSetCloner<HPolyhedron>, A.cols()), A_{A}, b_{b} {
   DRAKE_DEMAND(A.rows() == b.size());
 }
 
 HPolyhedron::HPolyhedron(const QueryObject<double>& query_object,
                          GeometryId geometry_id,
                          std::optional<FrameId> expressed_in)
-    : ConvexSet(ConvexSetTag<HPolyhedron>(), 3) {
+    : ConvexSet(&ConvexSetCloner<HPolyhedron>, 3) {
   std::pair<Eigen::MatrixXd, Eigen::VectorXd> Ab_G;
   query_object.inspector().GetShape(geometry_id).Reify(this, &Ab_G);
 
@@ -134,7 +142,7 @@ void HPolyhedron::ImplementGeometry(const Box& box, void* data) {
 
 HyperEllipsoid::HyperEllipsoid(const Eigen::Ref<const Eigen::MatrixXd>& A,
                                const Eigen::Ref<const Eigen::VectorXd>& center)
-    : ConvexSet(ConvexSetTag<HyperEllipsoid>(), center.size()),
+    : ConvexSet(&ConvexSetCloner<HyperEllipsoid>, center.size()),
       A_{A},
       center_{center} {
   DRAKE_DEMAND(A.rows() == center.size());
@@ -143,7 +151,7 @@ HyperEllipsoid::HyperEllipsoid(const Eigen::Ref<const Eigen::MatrixXd>& A,
 HyperEllipsoid::HyperEllipsoid(const QueryObject<double>& query_object,
                                GeometryId geometry_id,
                                std::optional<FrameId> expressed_in)
-    : ConvexSet(ConvexSetTag<HyperEllipsoid>(), 3) {
+    : ConvexSet(&ConvexSetCloner<HyperEllipsoid>, 3) {
   Eigen::Matrix3d A_G;
   query_object.inspector().GetShape(geometry_id).Reify(this, &A_G);
   // p_GG_varᵀ * A_Gᵀ * A_G * p_GG_var ≤ 1


### PR DESCRIPTION
This saves more than 10 KB of object code in a Release build, and will be friendlier in case we ever need to subclass in pydrake.

Also fix the constructor Doxygen to avoid triple backticks, which apparently don't render correctly.